### PR TITLE
fix(block-extraction): Tree-sitter over regexing

### DIFF
--- a/test/rg_for_block_text.txt
+++ b/test/rg_for_block_text.txt
@@ -1,0 +1,1 @@
+** Test Flights: 14 August 2024


### PR DESCRIPTION
Closes #5 

Relying on Tree-sitter over regex because there are n-number of ways someone can write their headings. And if its allowed by the Neorg parser, then I will have to account for those variations through regex.

Instead, it is sufficient to detect the heading text (which is always preceded by *'s which can be regex searched through ripgrep). Then, sending the selected file and linenumber to a tree-sitter parser to extract the exact heading text.