### PR TITLE
fix(backlinks): Escaping lines that start with @ in backlinks block

### DIFF
--- a/lua/neorg/modules/external/roam/module.lua
+++ b/lua/neorg/modules/external/roam/module.lua
@@ -692,6 +692,9 @@ module.public = {
 					for row in io.lines(file) do
 						curr_row = curr_row + 1
 						if curr_row >= startrow and curr_row <= endrow then
+                            -- Escape out any lines that start with @
+                            -- because it can interfere with the @code ... @end block
+                            row = row:gsub("^@", "\\@")
 							table.insert(buffer_lines, row)
 						end
 					end

--- a/lua/neorg/modules/external/roam/module.lua
+++ b/lua/neorg/modules/external/roam/module.lua
@@ -692,9 +692,9 @@ module.public = {
 					for row in io.lines(file) do
 						curr_row = curr_row + 1
 						if curr_row >= startrow and curr_row <= endrow then
-                            -- Escape out any lines that start with @
-                            -- because it can interfere with the @code ... @end block
-                            row = row:gsub("^@", "\\@")
+							-- Escape out any lines that start with @
+							-- because it can interfere with the @code ... @end block
+							row = row:gsub("^@", "\\@")
 							table.insert(buffer_lines, row)
 						end
 					end


### PR DESCRIPTION
This used to interfere with the @code ... @end backlink blocks in
excerpts. But now it doesn't anymore.