### PR TITLE
fix(fzf-lua): `<C-n>` wasn't properly closing fzf prompt

### DIFF
--- a/lua/neorg/modules/external/roam/module.lua
+++ b/lua/neorg/modules/external/roam/module.lua
@@ -340,6 +340,7 @@ module.public = {
 							vim.fn.mkdir(vault_dir, "p")
 
 							-- Create and open a new Neorg file with the generated title token
+							vim.cmd("q")
 							vim.cmd("edit " .. vault_dir .. "/" .. os.date("%Y%m%d%H%M%S-") .. title_token .. ".norg")
 							vim.cmd([[Neorg inject-metadata]])
 


### PR DESCRIPTION
It was getting stuck and new node buffer was opening in the fzf buffer.