### PR TITLE
Add workspace config option for agenda

### DIFF
--- a/lua/neorg/modules/external/agenda/module.lua
+++ b/lua/neorg/modules/external/agenda/module.lua
@@ -6,11 +6,16 @@ module.setup = function()
 		success = true,
 		requires = {
 			"core.neorgcmd",
+			"core.dirman",
 			"core.integrations.treesitter",
 			"external.many-mans",
 		},
 	}
 end
+
+module.config.public = {
+	workspace = nil
+}
 
 module.load = function()
 	module.required["core.neorgcmd"].add_commands_from_table({
@@ -424,13 +429,16 @@ module.public = {
 		table.insert(buffer_lines, "")
 		table.insert(buffer_lines, "")
 
+		local workspace = module.required["core.dirman"].get_workspace(module.config.public.workspace)
+		local base_directory
+		if workspace ~= nil then base_directory = workspace:tostring() end
 		local task_list = module.required["external.many-mans"]["task-man"].filter_tasks({
 			"undone",
 			"pending",
 			"hold",
 			"important",
 			"ambiguous",
-		})
+		}, base_directory)
 
 		local today = {}
 		local overdue = {}

--- a/lua/neorg/modules/external/many-mans/module.lua
+++ b/lua/neorg/modules/external/many-mans/module.lua
@@ -582,9 +582,9 @@ module.public = {
 			return task
 		end,
 
-		filter_tasks = function(input_list)
+		filter_tasks = function(input_list, base_directory)
 			local blacklisted_state_icons = module.public["task-man"].blacklist_states(input_list)
-			local base_directory = module.required["core.dirman"].get_current_workspace()[2]
+			if base_directory == nil then base_directory = module.required["core.dirman"].get_current_workspace()[2] end
 			local lines = module.public["task-man"].find_tasks_in_workspace(base_directory)
 
 			-- Filter and map tasks


### PR DESCRIPTION
Title.

Basically it's nice to be able to have a separate workspace just for todos, especially because there's currently no way to differentiate between just regular headings that have a done/undone status vs. actual todo items that should show up on the agenda.

With this change you can set the workspace for the agenda module:

```lua
["external.agenda"] = {
  config = {
    workspace = "todos", -- or "tasks", etc.
  }
}
```