### PR TITLE
No title or name in the node filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ return {
                         fuzzy_finder = "Telescope", -- OR "Fzf" OR "Snacks". Defaults to "Telescope"
                         fuzzy_backlinks = false, -- Set to "true" for backlinks in fuzzy finder instead of buffer
                         roam_base_directory = "", -- Directory in current workspace to store roam nodes
+                        node_no_name = false, -- no suffix name in node filename
                         node_name_randomiser = false, -- Tokenise node name suffix for more randomisation
                         node_name_snake_case = false, -- snake_case the names if node_name_randomiser = false
                     }

--- a/lua/neorg/modules/external/roam/module.lua
+++ b/lua/neorg/modules/external/roam/module.lua
@@ -455,7 +455,9 @@ module.public = {
 
 							-- Create and open a new Neorg file with the generated title token
 							vim.cmd("q")
-							vim.cmd("edit " .. vault_dir .. "/" .. os.date("%Y%m%d%H%M%S-") .. title_token .. ".norg")
+							title_token = module.config.public.node_no_name and "" or "-" .. title_token
+
+							vim.cmd("edit " .. vault_dir .. os.date("%Y%m%d%H%M%S") .. title_token .. ".norg")
 							vim.cmd([[Neorg inject-metadata]])
 
 							-- Update the title in the newly created buffer
@@ -529,7 +531,9 @@ module.public = {
 						vim.fn.mkdir(vault_dir, "p")
 
 						-- Create and open a new Neorg file with the generated title token
-						vim.cmd("edit " .. vault_dir .. "/" .. os.date("%Y%m%d%H%M%S-") .. title_token .. ".norg")
+							title_token = module.config.public.node_no_name and "" or "-" .. title_token
+
+							vim.cmd("edit " .. vault_dir .. os.date("%Y%m%d%H%M%S") .. title_token .. ".norg")
 						vim.cmd([[Neorg inject-metadata]])
 
 						-- Update the title in the newly created buffer

--- a/lua/neorg/modules/external/roam/module.lua
+++ b/lua/neorg/modules/external/roam/module.lua
@@ -17,6 +17,7 @@ module.config.public = {
 	fuzzy_finder = "Telescope", -- or "Fzf" or "Snacks"
 	fuzzy_backlinks = false,
 	roam_base_directory = "",
+	node_no_name = false,
 	node_name_randomiser = false,
 	node_name_snake_case = false,
 }
@@ -355,7 +356,9 @@ module.public = {
 							vim.fn.mkdir(vault_dir, "p")
 
 							-- Create and open a new Neorg file with the generated title token
-							vim.cmd("edit " .. vault_dir .. os.date("%Y%m%d%H%M%S-") .. title_token .. ".norg")
+							title_token = module.config.public.node_no_name and "" or "-" .. title_token
+
+							vim.cmd("edit " .. vault_dir .. os.date("%Y%m%d%H%M%S") .. title_token .. ".norg")
 							vim.cmd([[Neorg inject-metadata]])
 
 							-- Update the title in the newly created buffer


### PR DESCRIPTION
I like to have no name or title in the filename and just keep all the things clean with the hash related to the creation time.

So on the creation of a new node, its filename should be like this: **20250706165439.norg** for instance.

This add a new config parameter : **node_no_name = boolean** (which is false by default)

So my configuration:
```lua
    ["external.roam"] = {
      config = {
        fuzzy_backlinks = true,
        roam_base_directory = "NOTES/",
        node_no_name = true,
      },
    },
```

If this pull request is accepted, then I will update de documentation with one another pull request later.

All the best!